### PR TITLE
Fix a PHP typing issue

### DIFF
--- a/src/mail/MailchimpTransactionalTransport.php
+++ b/src/mail/MailchimpTransactionalTransport.php
@@ -288,7 +288,7 @@ class MailchimpTransactionalTransport implements Swift_Transport
      * @param Swift_Mime_SimpleMessage $message
      * @return string|null
      */
-    protected function getMessagePrimaryContentType(Swift_Mime_SimpleMessage $message): string
+    protected function getMessagePrimaryContentType(Swift_Mime_SimpleMessage $message): ?string
     {
         $contentType = $message->getContentType();
 


### PR DESCRIPTION
This issue prevents the email settings from being tested in the CP or using the `craft mailer/test` console command.