### PR TITLE
fix: sending email with a restricted API key

### DIFF
--- a/src/mail/MailchimpTransactionalTransport.php
+++ b/src/mail/MailchimpTransactionalTransport.php
@@ -27,6 +27,7 @@ use Swift_TransportException;
  * @author    Perfect Web Team
  * @package   Mailchimp Transactional
  * @since     1.0.0
+ * @property-read ?array $resultApi
  */
 class MailchimpTransactionalTransport implements Swift_Transport
 {
@@ -217,7 +218,7 @@ class MailchimpTransactionalTransport implements Swift_Transport
 
         //  Use template if configured
         if ($this->template) {
-            $this->resultApi = $mailchimpTransactional->messages->sendTemplate([
+            $response = $mailchimpTransactional->messages->sendTemplate([
                 'template_name' => $this->template,
                 'template_content' => [
                     [
@@ -228,11 +229,22 @@ class MailchimpTransactionalTransport implements Swift_Transport
                 'message' => $mailchimpTransactionalMessage,
                 'async' => $this->async
             ]);
+
+            if ($response instanceof \Throwable) {
+                throw $response;
+            }
+
+            $this->resultApi = $response;
         } else {
-            $this->resultApi = $mailchimpTransactional->messages->send([
+            $response = $mailchimpTransactional->messages->send([
                 'message' => $mailchimpTransactionalMessage,
                 'async' => $this->async
             ]);
+             if ($response instanceof \Throwable) {
+                 throw $response;
+             }
+
+            $this->resultApi = $response;
         }
 
         foreach ($this->resultApi as $item) {


### PR DESCRIPTION
Improve the error displayed when trying to send an email with a restricted API key if the API call didn't pass the restriction

Exemple: Trying to send an email from a server haviing the x.x.x.x IP address using an API key that is only allowed from IP y.y.y.y