### PR TITLE
allow for custom return-path domains with config array

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+
+    /**
+     * register Return-Path domains in Mandrill: https://mandrillapp.com/settings/tracking-domains
+     * to allow for a custom Return-Path as described here: https://mailchimp.com/developer/transactional/docs/authentication-delivery/#custom-return-path-domains
+     */
+    'returnPaths' => [
+        // 'senderDomain' => 'returnPathDomain'
+        // 'domain.com' => 'mandrill.domain.com'
+    ]
+];

--- a/src/mail/MailchimpTransactionalTransport.php
+++ b/src/mail/MailchimpTransactionalTransport.php
@@ -191,6 +191,18 @@ class MailchimpTransactionalTransport extends AbstractApiTransport
             $payload['message']['headers'][$header->getName()] = $header->getBodyAsString();
         }
 
+        /**
+         * register Return-Path domains in Mandrill: https://mandrillapp.com/settings/tracking-domains
+         * to allow for a custom Return-Path as described here: https://mailchimp.com/developer/transactional/docs/authentication-delivery/#custom-return-path-domains
+         */
+        $customConfig = \Craft::$app->config->getConfigFromFile('mailchimp-transactional');
+        $returnPaths = $customConfig['returnPaths'] ?? [];
+        foreach ($returnPaths as $senderDomain => $returnPathDomain) {
+            if (str_contains($envelope->getSender()->getAddress(), "@$senderDomain")) {
+                $payload['message']['return_path_domain'] = $returnPathDomain;
+            }
+        }
+
         return $payload;
     }
 


### PR DESCRIPTION
Allow for a custom Return-Path as described here: https://mailchimp.com/developer/transactional/docs/authentication-delivery/#custom-return-path-domains

Added a template config.php that should be copied to config/mailchimp-transactional.php