### PR TITLE
create settings model to avoid warning in logs

### DIFF
--- a/src/MailchimpTransactional.php
+++ b/src/MailchimpTransactional.php
@@ -8,10 +8,13 @@
 
 namespace perfectwebteam\mailchimptransactional;
 
+use Craft;
+use craft\base\Model;
 use craft\base\Plugin;
 use craft\events\RegisterComponentTypesEvent;
 use craft\helpers\MailerHelper;
 use perfectwebteam\mailchimptransactional\mail\MailchimpTransactionalAdapter;
+use perfectwebteam\mailchimptransactional\models\Settings;
 use yii\base\Event;
 
 /**
@@ -20,6 +23,7 @@ use yii\base\Event;
  * @author    Perfect Web Team
  * @package   Mailchimp Transactional
  * @since     1.0.0
+ * @method Settings getSettings()
  */
 class MailchimpTransactional extends Plugin
 {
@@ -48,5 +52,10 @@ class MailchimpTransactional extends Plugin
                 $event->types[] = MailchimpTransactionalAdapter::class;
             }
         );
+    }
+
+    protected function createSettingsModel(): ?Model
+    {
+        return Craft::createObject(Settings::class);
     }
 }

--- a/src/mail/MailchimpTransactionalTransport.php
+++ b/src/mail/MailchimpTransactionalTransport.php
@@ -9,6 +9,7 @@
 namespace perfectwebteam\mailchimptransactional\mail;
 
 use Craft;
+use perfectwebteam\mailchimptransactional\MailchimpTransactional;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
@@ -191,8 +192,7 @@ class MailchimpTransactionalTransport extends AbstractApiTransport
 
             $payload['message']['headers'][$header->getName()] = $header->getBodyAsString();
 
-            $customConfig = Craft::$app->config->getConfigFromFile('mailchimp-transactional');
-            $returnPaths = $customConfig['returnPaths'] ?? [];
+            $returnPaths = MailchimpTransactional::getInstance()->getSettings()->returnPaths ?? [];
 
             foreach ($returnPaths as $senderDomain => $returnPathDomain) {
                 if (str_contains($envelope->getSender()->getAddress(), "@$senderDomain")) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace perfectwebteam\mailchimptransactional\models;
+
+use craft\base\Model;
+
+/**
+ * MailchimpTransactional settings
+ */
+class Settings extends Model
+{
+    public $returnPaths = null;
+}


### PR DESCRIPTION
Hi @sanderpotjer 

In #9, a config file could be added to configure the Return-Paths.
But without a Settings model on the plugin, the logs get flooded with this warning:
```
[web.WARNING] [application] Attempting to set settings on a plugin that doesn't have settings: mailchimp-transactional
```

So I refactored this part to get the value from a Settings model